### PR TITLE
Update readme.md for mongo shell command

### DIFF
--- a/samples/volumes/pv-pvc-sc-cm/readme.md
+++ b/samples/volumes/pv-pvc-sc-cm/readme.md
@@ -32,7 +32,7 @@ only use the local-storage option, however in cloud scenarios the SC/PVC could b
     `kubectl create -f mongo.deployment.yml`
 
 4. Run `kubectl get pods` to see the pod.
-5. Run `kubectl exec [mongo-pod-name] -it sh` to shell into the container. Run the `mongo` command to make sure the database is working. Type `exit` to exit the shell.
+5. Run `kubectl exec [mongo-pod-name] -it sh` to shell into the container. Run the `mongosh` command to make sure the database is working. Type `exit` to exit the shell.
 
     Note: If you have a tool that can hit MongoDB externally you can `kubectl port-forward` to the pod to expose 27017.
 


### PR DESCRIPTION
Replace "mongo" with "mongosh" command.

As in the course it's used always the latest mongo version: "The legacy mongo shell was deprecated in MongoDB 5.0 and removed in MongoDB 6.0 in favor of the new MongoDB Shell, mongosh. Some legacy methods are unavailable or have been replaced with updated methods in mongosh. To maintain backwards compatibility, the legacy methods that mongosh supports use the same syntax as the corresponding methods in the mongo shell."

Reference: https://www.mongodb.com/docs/mongodb-shell/