### PR TITLE
Fix node.deployment.yml

### DIFF
--- a/samples/configMaps/node.deployment.yml
+++ b/samples/configMaps/node.deployment.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: node-configmap
-        image: node-configmap
+        image: node:alpine
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
======= Applied fix for following issue

1.  Create deployment

    ```
    ❯ kubectl apply -f node.deployment.yml 
    deployment.apps/node-configmap created
    ```

2. Overview pods - Not running

    ```
    ❯ kubectl get pods                                           
    NAME                              READY        STATUS             RESTARTS            AGE
    node-configmap-5565578cf5-brprr   0/1          ImagePullBackOff   0                   4m9s
    ```

3. Investigate pod description to see what's wrong
    ```
    ❯ kubectl pod node-configmap-5565578cf5-brprr 
    Name:             node-configmap-5565578cf5-brprr
    Namespace:        default
    Priority:         0
    Service Account:  default
    Node:             docker-desktop/192.168.65.4
    Start Time:       Wed, 04 Oct 2023 23:28:00 +0300
    Labels:           app=node-configmap
                      pod-template-hash=5565578cf5
    Annotations:      <none>
    Status:           Pending
    IP:               10.1.0.126
    IPs:
      IP:           10.1.0.126
    Controlled By:  ReplicaSet/node-configmap-5565578cf5
    Containers:
      node-configmap:
        Container ID:   
        Image:          node-configmap
        Image ID:       
        Port:           9000/TCP
        Host Port:      0/TCP
        State:          Waiting
          Reason:       ImagePullBackOff
        Ready:          False
    ...
    Conditions:
      Type              Status
      Initialized       True 
      Ready             False 
      ContainersReady   False 
      PodScheduled      True 
    ...
    Events:
      Type     Reason     Age                    From               Message
      ----     ------     ----                   ----               -------
      Normal   Scheduled  4m22s                  default-scheduler  Successfully assigned default/node-configmap-5565578cf5-brprr to docker-desktop
      Warning  Failed     4m7s                   kubelet            Failed to pull image "node-configmap": rpc error: code = Unknown desc = Error response from daemon: Head "https://registry-1.docker.io/v2/library/node-configmap/manifests/latest": received unexpected HTTP status: 500 Internal Server Error
      Normal   Pulling    2m48s (x4 over 4m22s)  kubelet            Pulling image "node-configmap"
      Warning  Failed     2m46s (x3 over 4m20s)  kubelet            Failed to pull image "node-configmap": rpc error: code = Unknown desc = Error response from daemon: pull access denied for node-configmap, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
      Warning  Failed     2m46s (x4 over 4m20s)  kubelet            Error: ErrImagePull
      Warning  Failed     2m35s (x6 over 4m20s)  kubelet            Error: ImagePullBackOff
    ```