### PR TITLE
fixes long dashes  that don't work when copied and pasted

### DIFF
--- a/labs/Hooking Source Code into a Container using a Volume/End/src/Dockerfile
+++ b/labs/Hooking Source Code into a Container using a Volume/End/src/Dockerfile
@@ -8,4 +8,4 @@ COPY        . /usr/share/nginx/html
 EXPOSE      80
 CMD         ["nginx", "-g", "daemon off;"]
 
-# Run using: docker run –d -p 8080:80 -v [currentWorkingDirectory]:/usr/share/nginx/html nginx:alpine
+# Run using: docker run -d -p 8080:80 -v [currentWorkingDirectory]:/usr/share/nginx/html nginx:alpine

--- a/samples/pods/nginx.pod.yml
+++ b/samples/pods/nginx.pod.yml
@@ -13,12 +13,12 @@ spec:
     - containerPort: 80
     resources: {}
       
-# kubectl create –f nginx.pod.yml --save-config
+# kubectl create -f nginx.pod.yml --save-config
 # kubectl describe pod [pod-name]
-# kubectl apply –f nginx.pod.yml
+# kubectl apply -f nginx.pod.yml
 # kubectl exec [pod-name] -it sh
 # kubectl edit -f nginx.pod.yml
-# Kubectl delete –f nginx.pod.yml
+# Kubectl delete -f nginx.pod.yml
 
 # To exec into container use:
 # kubectl exec pod-name -it sh


### PR DESCRIPTION
There's an long dash (en dash?) like this `–` which needs to be a `-` instead. When you copy and paste them it errors:

```bash
kubectl create –f nginx.pod.yml --save-config
Error: must specify one of -f and -k

error: unknown command "–f nginx.pod.yml"
See 'kubectl create -h' for help and examples
```