### PR TITLE
Change on Image Name for the Liveness Probe Sample

### DIFF
--- a/samples/pods/busybox-liveness-probe.pod.yml
+++ b/samples/pods/busybox-liveness-probe.pod.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: liveness
-    image: k8s.gcr.io/busybox
+    image: busybox
     resources:
       limits:
         memory: "64Mi" #64 MB


### PR DESCRIPTION
The old image name is causing a "ImagePullBackOff" status when the pod is being created, refreshing this to the image name that works.